### PR TITLE
fix: Fix overflow if too many items on a `StockholmMenu`

### DIFF
--- a/lib/src/menu_items.dart
+++ b/lib/src/menu_items.dart
@@ -24,26 +24,44 @@ class StockholmMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     var isWindows = Theme.of(context).platform == TargetPlatform.windows;
 
-    return Container(
-      decoration: BoxDecoration(
-          color: Theme.of(context).popupMenuTheme.color,
-          borderRadius: BorderRadius.all(Radius.circular(isWindows ? 3 : 8)),
-          boxShadow: const [
-            BoxShadow(
-              color: Colors.black26,
-              blurRadius: 16,
-              offset: Offset(0, 4),
-            )
-          ],
-          border: Border.all(color: Theme.of(context).dividerColor)),
-      padding: isWindows ? _menuPaddingWindows : _menuPadding,
-      child: IntrinsicWidth(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: items,
-        ),
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxHeight = constraints.maxHeight;
+        final contentHeight = height;
+        final needsScroll = contentHeight > maxHeight;
+
+        final menuContent = IntrinsicWidth(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: items,
+          ),
+        );
+
+        return Container(
+          decoration: BoxDecoration(
+              color: Theme.of(context).popupMenuTheme.color,
+              borderRadius:
+                  BorderRadius.all(Radius.circular(isWindows ? 3 : 8)),
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.black26,
+                  blurRadius: 16,
+                  offset: Offset(0, 4),
+                )
+              ],
+              border: Border.all(color: Theme.of(context).dividerColor)),
+          padding: isWindows ? _menuPaddingWindows : _menuPadding,
+          child: needsScroll
+              ? ConstrainedBox(
+                  constraints: BoxConstraints(maxHeight: maxHeight),
+                  child: SingleChildScrollView(
+                    child: menuContent,
+                  ),
+                )
+              : menuContent,
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/serverpod/serverpod/issues/4767.

If the content overflows the maximum height now, a slightly transparent scroll bar will appear while scrolling, and disappear gracefully after scroll has stopped.

<img width="181" height="578" alt="image" src="https://github.com/user-attachments/assets/0f123284-1821-4b9d-8ce1-7f6f67707b14" />

<img width="183" height="527" alt="image" src="https://github.com/user-attachments/assets/28ffa86f-9553-49d3-aa11-c439d611ee3d" />
