### PR TITLE
fix: Sync `StockholmTable` selection when `selectedRow` prop changes

### DIFF
--- a/lib/src/table.dart
+++ b/lib/src/table.dart
@@ -250,6 +250,9 @@ class _StockholmTableState extends State<StockholmTable> {
   @override
   void didUpdateWidget(covariant StockholmTable oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.selectedRow != oldWidget.selectedRow) {
+      _selectedRow = widget.selectedRow;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _checkScrollPosition();
     });


### PR DESCRIPTION
## Problem

`StockholmTable` stores the selected row index in `_selectedRow`, set from `widget.selectedRow` only in `initState`. When the parent passes an updated `selectedRow` (for example after the underlying list changes and the selected item moves to a new index), the internal state was not updated, so the highlight stayed on the old row index.

## Fix

In `didUpdateWidget`, when `widget.selectedRow` differs from the previous value, assign `_selectedRow = widget.selectedRow` so controlled selection stays aligned with the parent.

## Context

This was observed in Serverpod Insights when new session logs arrive at the top of the list while a row is selected.