### PR TITLE
fix: Replace ionicons with ionicons_plus for Flutter 3.44+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+* Replaces `ionicons` with `ionicons_plus` for compatibility with Flutter 3.44+ where `IconData` is final.
+
 ## 0.2.2
 
 * Tightens spacing in `StockholmDateTimePicker` so date and time read as one continuous line.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:example/src/tables.dart';
 import 'package:example/src/text_fields.dart';
 import 'package:example/src/toolbar.dart';
 import 'package:flutter/material.dart';
-import 'package:ionicons/ionicons.dart';
+import 'package:ionicons_plus/ionicons_plus.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:stockholm/stockholm.dart';
 

--- a/example/lib/src/colors.dart
+++ b/example/lib/src/colors.dart
@@ -1,6 +1,6 @@
 import 'package:example/src/demo_page.dart';
 import 'package:flutter/material.dart';
-import 'package:ionicons/ionicons.dart';
+import 'package:ionicons_plus/ionicons_plus.dart';
 import 'package:stockholm/stockholm.dart';
 
 class StockholmColorDemoPage extends StatelessWidget {

--- a/example/lib/src/toolbar.dart
+++ b/example/lib/src/toolbar.dart
@@ -1,6 +1,6 @@
 import 'package:example/src/demo_page.dart';
 import 'package:flutter/material.dart';
-import 'package:ionicons/ionicons.dart';
+import 'package:ionicons_plus/ionicons_plus.dart';
 import 'package:stockholm/stockholm.dart';
 
 class StockholmToolbarDemoPage extends StatelessWidget {

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,11 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+}

--- a/example/linux/flutter/generated_plugin_registrant.h
+++ b/example/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,23 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,14 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  ionicons:
+  ionicons_plus:
     dependency: "direct main"
     description:
-      name: ionicons
-      sha256: "5496bc65a16115ecf05b15b78f494ee4a8869504357668f0a11d689e970523cf"
+      name: ionicons_plus
+      sha256: "9f5a837f1a0df204f3d11fc4a8adbd870c5239e21b25e8df68504e227084e86f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -182,7 +182,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.2.3"
   stream_channel:
     dependency: transitive
     description:
@@ -233,4 +233,4 @@ packages:
     version: "13.0.0"
 sdks:
   dart: ">=3.9.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.4"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,7 +29,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ionicons: ^0.2.2
+  ionicons_plus: ^0.2.5
   material_design_icons_flutter: 6.0.7096
   stockholm:
     path: ..

--- a/lib/src/expansion_tile.dart
+++ b/lib/src/expansion_tile.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:ionicons/ionicons.dart';
+import 'package:ionicons_plus/ionicons_plus.dart';
 
 class StockholmExpansionTile extends StatefulWidget {
   const StockholmExpansionTile({

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,14 +67,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  ionicons:
+  ionicons_plus:
     dependency: "direct main"
     description:
-      name: ionicons
-      sha256: "5496bc65a16115ecf05b15b78f494ee4a8869504357668f0a11d689e970523cf"
+      name: ionicons_plus
+      sha256: "9f5a837f1a0df204f3d11fc4a8adbd870c5239e21b25e8df68504e227084e86f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -210,4 +210,4 @@ packages:
     version: "15.0.2"
 sdks:
   dart: ">=3.9.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stockholm
 description: A collection of desktop-first widgets and themes designed to look and feel great on Mac and Windows.
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/serverpod/stockholm
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ionicons: ^0.2.2
+  ionicons_plus: ^0.2.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The `IconData` class is now final in Flutter 3.44, which breaks the legacy `ionicons` package (which is also unmantained since 3 years). The `ionicons_plus` is a drop-in replacement with the same API.